### PR TITLE
fix dictionary merge for python 3

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -21,7 +21,7 @@ class TogglClientApi:
     requests = None
 
     def __init__(self, credentials):
-        self.credentials = dict(self.defaultCredentials.items() + credentials.items())
+        self.credentials = self.defaultCredentials | credentials
         self.api_base_url = self.build_api_url(self.credentials['base_url'], self.credentials['ver_api'])
         self.api_report_base_url = self.build_api_url(self.credentials['base_url_report'], self.credentials['ver_report'])
         self.api_token = self.credentials['token']


### PR DESCRIPTION
Python 3.9.5 (default, May 24 2021, 12:50:35) 

aside from this change, rest of it (for my purposes anyway) seemed to work in this version of python